### PR TITLE
Fix error when reading FAULTS keyword

### DIFF
--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -96,7 +96,10 @@ def parse_opmio_deckrecord(
 
     for item_idx, jsonitem in enumerate(itemlist):
         item_name = jsonitem["name"]
-        if not hasattr(record[item_idx], "defaulted") or not record[item_idx].defaulted(0):
+        if (
+            not hasattr(record[item_idx], "defaulted")
+            or not record[item_idx].defaulted(0)
+        ):
             rec_dict[item_name] = getattr(
                 record[item_idx], deckitem_fn[jsonitem["value_type"]]
             )(0)

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -96,7 +96,7 @@ def parse_opmio_deckrecord(
 
     for item_idx, jsonitem in enumerate(itemlist):
         item_name = jsonitem["name"]
-        if not record[item_idx].defaulted(0):
+        if not hasattr(record[item_idx], "defaulted") or not record[item_idx].defaulted(0):
             rec_dict[item_name] = getattr(
                 record[item_idx], deckitem_fn[jsonitem["value_type"]]
             )(0)


### PR DESCRIPTION
When reading a correct FAULTS keyword definition using ecl2df, with opm-common master branch clone from Mar 6, 2020 I bumped into the following error:

![image](https://user-images.githubusercontent.com/9119793/76208623-57284380-6200-11ea-89ef-fbe589a091da.png)

The change in this pull request fixes the problem. I'm unsure if this might lead to other unintended results. Please review.